### PR TITLE
New Exception Subclass For Determinant=0

### DIFF
--- a/classes/src/Builder.php
+++ b/classes/src/Builder.php
@@ -57,9 +57,9 @@ class Builder
      * @return Matrix
      * @throws Exception
      */
-    public static function createIdentityMatrix($dimensions)
+    public static function createIdentityMatrix($dimensions, $fillValue = null)
     {
-        $grid = static::createFilledMatrix(null, $dimensions)->toArray();
+        $grid = static::createFilledMatrix($fillValue, $dimensions)->toArray();
 
         for ($x = 0; $x < $dimensions; ++$x) {
             $grid[$x][$x] = 1;

--- a/classes/src/Div0Exception.php
+++ b/classes/src/Div0Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Exception.
+ *
+ * @copyright  Copyright (c) 2013-2018 Mark Baker (https://github.com/MarkBaker/PHPMatrix)
+ * @license    https://opensource.org/licenses/MIT    MIT
+ */
+namespace Matrix;
+
+class Div0Exception extends Exception
+{
+}

--- a/classes/src/Functions.php
+++ b/classes/src/Functions.php
@@ -229,15 +229,15 @@ class Functions
      * @return Matrix
      * @throws Exception
      **/
-    public static function inverse(Matrix $matrix)
+    public static function inverse(Matrix $matrix, string $type = 'inverse')
     {
         if (!$matrix->isSquare()) {
-            throw new Exception('Inverse can only be calculated for a square matrix');
+            throw new Exception(ucfirst($type) . ' can only be calculated for a square matrix');
         }
 
         $determinant = self::getDeterminant($matrix);
         if ($determinant == 0.0) {
-            throw new Exception('Inverse can only be calculated for a matrix with a non-zero determinant');
+            throw new Div0Exception(ucfirst($type) . ' can only be calculated for a matrix with a non-zero determinant');
         }
 
         if ($matrix->rows == 1) {

--- a/classes/src/Operators/Division.php
+++ b/classes/src/Operators/Division.php
@@ -2,9 +2,10 @@
 
 namespace Matrix\Operators;
 
+use Matrix\Div0Exception;
+use Matrix\Exception;
 use \Matrix\Matrix;
 use \Matrix\Functions;
-use Matrix\Exception;
 
 class Division extends Multiplication
 {
@@ -15,22 +16,18 @@ class Division extends Multiplication
      * @throws Exception If the provided argument is not appropriate for the operation
      * @return $this The operation object, allowing multiple divisions to be chained
      **/
-    public function execute($value): Operator
+    public function execute($value, string $type = 'division'): Operator
     {
         if (is_array($value)) {
             $value = new Matrix($value);
         }
 
         if (is_object($value) && ($value instanceof Matrix)) {
-            try {
-                $value = Functions::inverse($value);
-            } catch (Exception $e) {
-                throw new Exception('Division can only be calculated using a matrix with a non-zero determinant');
-            }
+            $value = Functions::inverse($value, $type);
 
-            return $this->multiplyMatrix($value);
+            return $this->multiplyMatrix($value, $type);
         } elseif (is_numeric($value)) {
-            return $this->multiplyScalar(1 / $value);
+            return $this->multiplyScalar(1 / $value, $type);
         }
 
         throw new Exception('Invalid argument for division');

--- a/unitTests/classes/src/BuilderTest.php
+++ b/unitTests/classes/src/BuilderTest.php
@@ -25,5 +25,23 @@ class BuilderTest extends BaseTestAbstract
             new Matrix([[1, null, null], [null, 1, null], [null, null, 1]]),
             $matrix
         );
+        $arr = $matrix->toArray();
+        $this->assertSame([1, null, null], $arr[0]);
+        $this->assertSame([null, 1, null], $arr[1]);
+        $this->assertSame([null, null, 1], $arr[2]);
+    }
+
+    public function testCreateIdentityMatrixWithZeros()
+    {
+        $matrix = Builder::createIdentityMatrix(3, 0);
+        $this->assertIsMatrixObject($matrix);
+        $this->assertEquals(
+            new Matrix([[1, null, 0], [0, 1, 0], [0, 0, 1]]),
+            $matrix
+        );
+        $arr = $matrix->toArray();
+        $this->assertSame([1, 0, 0], $arr[0]);
+        $this->assertSame([0, 1, 0], $arr[1]);
+        $this->assertSame([0, 0, 1], $arr[2]);
     }
 }

--- a/unitTests/classes/src/Functions/inverseTest.php
+++ b/unitTests/classes/src/Functions/inverseTest.php
@@ -2,6 +2,7 @@
 
 namespace MatrixTest\Functions;
 
+use Matrix\Div0Exception;
 use Matrix\Exception;
 use Matrix\Matrix;
 use Matrix\Functions as MatrixFunctions;
@@ -129,7 +130,17 @@ class inverseTest extends BaseTestAbstract
 
     public function testInverseWithZeroDeterminant()
     {
+        // Div0Exception is an extension of Exception
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Inverse can only be calculated for a matrix with a non-zero determinant');
+
+        $matrix = new Matrix([[1, 15, 14, 4], [12, 6, 7, 9], [8, 10, 11, 5], [13, 3, 2, 16]]);
+        $result = $matrix->inverse();
+    }
+
+    public function testInverseWithZeroDeterminant2()
+    {
+        $this->expectException(Div0Exception::class);
         $this->expectExceptionMessage('Inverse can only be calculated for a matrix with a non-zero determinant');
 
         $matrix = new Matrix([[1, 15, 14, 4], [12, 6, 7, 9], [8, 10, 11, 5], [13, 3, 2, 16]]);

--- a/unitTests/classes/src/FunctionsTest.php
+++ b/unitTests/classes/src/FunctionsTest.php
@@ -122,14 +122,22 @@ class FunctionsTest extends BaseTestAbstract
         $inverted3x3 = Functions::inverse($this->matrix3x3);
         $this->assertEquals($expectedInverted3x3, $inverted3x3);
         $this->assertEquals($this->matrix3x3, Functions::inverse($inverted3x3));
+    }
+
+    public function testInverseNotSquare(): void
+    {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('Inverse can only be calculated for a square matrix');
         Functions::inverse($this->matrix2x4);
+    }
+
+    public function testInverseNotSquare2(): void
+    {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('Inverse can only be calculated for a matrix with a non-zero determinant');
-        Functions::inverse($this->matrix1x1);
+        Functions::inverse(new Matrix([0]));
     }
 
     public function testMinors()

--- a/unitTests/classes/src/Operators/DivisionTest.php
+++ b/unitTests/classes/src/Operators/DivisionTest.php
@@ -2,8 +2,9 @@
 
 namespace MatrixTest\Operators;
 
-use Matrix\Matrix;
+use Matrix\Div0Exception;
 use Matrix\Exception;
+use Matrix\Matrix;
 use Matrix\Operators\Division;
 use MatrixTest\BaseTestAbstract;
 
@@ -31,6 +32,14 @@ class DivisionTest extends BaseTestAbstract
     {
         return new Matrix([
             [1, 2],
+            [3, 4],
+        ]);
+    }
+
+    protected function getTestMatrix4()
+    {
+        return new Matrix([
+            [1, 'invalid'],
             [3, 4],
         ]);
     }
@@ -143,9 +152,58 @@ class DivisionTest extends BaseTestAbstract
 
         $divisor = new Division($matrix);
 
+        // Div0Exception is an extension of Exception
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Division can only be calculated using a matrix with a non-zero determinant');
+        $this->expectExceptionMessage('Division can only be calculated for a matrix with a non-zero determinant');
         $result = $divisor->execute(new Matrix($this->getTestGrid1()))
+            ->result();
+    }
+
+    public function testDivideZeroDeterminant2()
+    {
+        $matrix = $this->getTestMatrix2();
+
+        $divisor = new Division($matrix);
+
+        $this->expectException(Div0Exception::class);
+        $this->expectExceptionMessage('Division can only be calculated for a matrix with a non-zero determinant');
+        $result = $divisor->execute(new Matrix($this->getTestGrid1()))
+            ->result();
+    }
+
+    public function testDivideNonNumeric()
+    {
+        $matrix = $this->getTestMatrix4();
+
+        $divisor = new Division($matrix);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid argument for division');
+        $result = $divisor->execute([[1, 2], [3, 4]])
+            ->result();
+    }
+
+    public function testDivideScalarNonNumericDivisor()
+    {
+        $matrix = $this->getTestMatrix4();
+
+        $divisor = new Division($matrix);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid argument for division');
+        $result = $divisor->execute(4)
+            ->result();
+    }
+
+    public function testDivideScalarNonNumericDividend()
+    {
+        $matrix = $this->getTestMatrix3();
+
+        $divisor = new Division($matrix);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid argument for division');
+        $result = $divisor->execute('invalid')
             ->result();
     }
 }

--- a/unitTests/classes/src/Operators/MultiplicationTest.php
+++ b/unitTests/classes/src/Operators/MultiplicationTest.php
@@ -35,6 +35,14 @@ class MultiplicationTest extends BaseTestAbstract
         ]);
     }
 
+    protected function getTestMatrix4()
+    {
+        return new Matrix([
+            [1, 2],
+            ['invalid', 4],
+        ]);
+    }
+
     public function testGetResult()
     {
         $original = $this->getTestGrid1();
@@ -139,6 +147,32 @@ class MultiplicationTest extends BaseTestAbstract
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Matrices have mismatched dimensions');
         $result = $multiplier->execute($this->getTestMatrix3())
+            ->result();
+    }
+
+    public function testMultiplyScalarNonNumericMatrix()
+    {
+        $matrix = $this->getTestMatrix4();
+
+        $multiplier = new Multiplication($matrix);
+        $multiplicand = 4;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid argument for multiplication');
+        $result = $multiplier->execute($multiplicand)
+            ->result();
+    }
+
+    public function testMultiplyNonNumericScalar()
+    {
+        $matrix = $this->getTestMatrix4();
+
+        $multiplier = new Multiplication($matrix);
+        $multiplicand = 4;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid argument for multiplication');
+        $result = $multiplier->execute($multiplicand)
             ->result();
     }
 }


### PR DESCRIPTION
I am continuing to work on breaking up PhpSpreadsheet MathTrig, and have arrived at the matrix functions. I believe it would be helpful if the "arithmetic" exception (failing inverse when determinant is 0, which should result in a NAN error) were to throw a more descriptive exception than others (matrix not square, containing non-arithmetic data, etc., which should result in a VALUE error). Hence, I have added MatrixDiv0Exception as an extension of MatrixException.

It is true that I can get by without this change, by querying the Exception message. That approach does not seem as clean as a separate Exception subclass.

I considered a separate exception for "not square", which turns up in a number of different places. I don't think I would need this distinction for PhpSpreadsheet, but could easily add it if you feel it might be useful.

The code for Division and Multiplication needed minor improvements. Division wrapped its inverse call in a try/catch, throwing "determinant non-zero" for catch. But, it might err in a different way, if the matrix contains a non-numeric value, or if it's not square. I think it should suffice to just let any exception be passed up the line, without even trying to catch it.

Multiplication implicitly throws an error for non-numeric values. It is changed to explicitly throw an exception. I suspect there are probably other problems of this ilk; I am not attempting to be comprehensive.

The exception message for Inverse has been changed to be consistent with  Division.