### PR TITLE
Apply function-exists check around all function definitions.

### DIFF
--- a/classes/src/Functions/adjoint.php
+++ b/classes/src/Functions/adjoint.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The new matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function adjoint($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\adjoint')) {
+    function adjoint($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::adjoint($matrix);
+        return Functions::adjoint($matrix);
+    }
 }

--- a/classes/src/Functions/antidiagonal.php
+++ b/classes/src/Functions/antidiagonal.php
@@ -16,14 +16,16 @@ namespace Matrix;
  * @return    Matrix           The new matrix
  * @throws    Exception        If argument isn't a valid matrix or array.
  */
-function antidiagonal($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\antidiagonal')) {
+    function antidiagonal($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::antidiagonal($matrix);
+        return Functions::antidiagonal($matrix);
+    }
 }

--- a/classes/src/Functions/cofactors.php
+++ b/classes/src/Functions/cofactors.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The new matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function cofactors($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\cofactors')) {
+    function cofactors($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::cofactors($matrix);
+        return Functions::cofactors($matrix);
+    }
 }

--- a/classes/src/Functions/determinant.php
+++ b/classes/src/Functions/determinant.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return float Matrix determinant
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function determinant($matrix): float
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\determinant')) {
+    function determinant($matrix): float
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::determinant($matrix);
+        return Functions::determinant($matrix);
+    }
 }

--- a/classes/src/Functions/diagonal.php
+++ b/classes/src/Functions/diagonal.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The new matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function diagonal($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\diagonal')) {
+    function diagonal($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::diagonal($matrix);
+        return Functions::diagonal($matrix);
+    }
 }

--- a/classes/src/Functions/identity.php
+++ b/classes/src/Functions/identity.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The identity matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function identity($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\identity')) {
+    function identity($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::identity($matrix);
+        return Functions::identity($matrix);
+    }
 }

--- a/classes/src/Functions/inverse.php
+++ b/classes/src/Functions/inverse.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The new matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function inverse($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\inverse')) {
+    function inverse($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::inverse($matrix);
+        return Functions::inverse($matrix);
+    }
 }

--- a/classes/src/Functions/minors.php
+++ b/classes/src/Functions/minors.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The new matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function minors($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\minors')) {
+    function minors($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::minors($matrix);
+        return Functions::minors($matrix);
+    }
 }

--- a/classes/src/Functions/trace.php
+++ b/classes/src/Functions/trace.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return float The trace of the matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function trace($matrix): float
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\trace')) {
+    function trace($matrix): float
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::trace($matrix);
+        return Functions::trace($matrix);
+    }
 }

--- a/classes/src/Functions/transpose.php
+++ b/classes/src/Functions/transpose.php
@@ -17,14 +17,16 @@ namespace Matrix;
  * @return Matrix The transposed matrix
  * @throws Exception If argument isn't a valid matrix or array.
  */
-function transpose($matrix): Matrix
-{
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Must be Matrix or array');
-    }
+if (!function_exists(__NAMESPACE__ . '\\transpose')) {
+    function transpose($matrix): Matrix
+    {
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Must be Matrix or array');
+        }
 
-    return Functions::transpose($matrix);
+        return Functions::transpose($matrix);
+    }
 }

--- a/classes/src/Operations/add.php
+++ b/classes/src/Operations/add.php
@@ -19,26 +19,28 @@ use Matrix\Operators\Addition;
  * @return Matrix
  * @throws Exception
  */
-function add(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('Addition operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\add')) {
+    function add(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('Addition operation requires at least 2 arguments');
+        }
+
+        $matrix = array_shift($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Addition arguments must be Matrix or array');
+        }
+
+        $result = new Addition($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_shift($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Addition arguments must be Matrix or array');
-    }
-
-    $result = new Addition($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }

--- a/classes/src/Operations/directsum.php
+++ b/classes/src/Operations/directsum.php
@@ -19,26 +19,28 @@ use Matrix\Operators\DirectSum;
  * @return Matrix
  * @throws Exception
  */
-function directsum(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('DirectSum operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\directsum')) {
+    function directsum(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('DirectSum operation requires at least 2 arguments');
+        }
+
+        $matrix = array_shift($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('DirectSum arguments must be Matrix or array');
+        }
+
+        $result = new DirectSum($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_shift($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('DirectSum arguments must be Matrix or array');
-    }
-
-    $result = new DirectSum($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }

--- a/classes/src/Operations/divideby.php
+++ b/classes/src/Operations/divideby.php
@@ -19,26 +19,28 @@ use Matrix\Operators\Division;
  * @return Matrix
  * @throws Exception
  */
-function divideby(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('Division operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\divideby')) {
+    function divideby(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('Division operation requires at least 2 arguments');
+        }
+
+        $matrix = array_shift($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Division arguments must be Matrix or array');
+        }
+
+        $result = new Division($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_shift($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Division arguments must be Matrix or array');
-    }
-
-    $result = new Division($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }

--- a/classes/src/Operations/divideinto.php
+++ b/classes/src/Operations/divideinto.php
@@ -19,27 +19,29 @@ use Matrix\Operators\Division;
  * @return Matrix
  * @throws Exception
  */
-function divideinto(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('Division operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\divideinto')) {
+    function divideinto(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('Division operation requires at least 2 arguments');
+        }
+
+        $matrix = array_pop($matrixValues);
+        $matrixValues = array_reverse($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Division arguments must be Matrix or array');
+        }
+
+        $result = new Division($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_pop($matrixValues);
-    $matrixValues = array_reverse($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Division arguments must be Matrix or array');
-    }
-
-    $result = new Division($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }

--- a/classes/src/Operations/multiply.php
+++ b/classes/src/Operations/multiply.php
@@ -19,26 +19,28 @@ use Matrix\Operators\Multiplication;
  * @return Matrix
  * @throws Exception
  */
-function multiply(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('Multiplication operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\multiply')) {
+    function multiply(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('Multiplication operation requires at least 2 arguments');
+        }
+
+        $matrix = array_shift($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Multiplication arguments must be Matrix or array');
+        }
+
+        $result = new Multiplication($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_shift($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Multiplication arguments must be Matrix or array');
-    }
-
-    $result = new Multiplication($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }

--- a/classes/src/Operations/subtract.php
+++ b/classes/src/Operations/subtract.php
@@ -19,26 +19,28 @@ use Matrix\Operators\Subtraction;
  * @return Matrix
  * @throws Exception
  */
-function subtract(...$matrixValues): Matrix
-{
-    if (count($matrixValues) < 2) {
-        throw new Exception('Subtraction operation requires at least 2 arguments');
+if (!function_exists(__NAMESPACE__ . '\\subtract')) {
+    function subtract(...$matrixValues): Matrix
+    {
+        if (count($matrixValues) < 2) {
+            throw new Exception('Subtraction operation requires at least 2 arguments');
+        }
+
+        $matrix = array_shift($matrixValues);
+
+        if (is_array($matrix)) {
+            $matrix = new Matrix($matrix);
+        }
+        if (!$matrix instanceof Matrix) {
+            throw new Exception('Subtraction arguments must be Matrix or array');
+        }
+
+        $result = new Subtraction($matrix);
+
+        foreach ($matrixValues as $matrix) {
+            $result->execute($matrix);
+        }
+
+        return $result->result();
     }
-
-    $matrix = array_shift($matrixValues);
-
-    if (is_array($matrix)) {
-        $matrix = new Matrix($matrix);
-    }
-    if (!$matrix instanceof Matrix) {
-        throw new Exception('Subtraction arguments must be Matrix or array');
-    }
-
-    $result = new Subtraction($matrix);
-
-    foreach ($matrixValues as $matrix) {
-        $result->execute($matrix);
-    }
-
-    return $result->result();
 }


### PR DESCRIPTION
Apply function-exists check around all function definitions. This is a problem for WP users who are using plug-ins that haven't been properly created with PHPScoper, and they blame my libraries rather than the plug-in creators, who don't understand how a plug-in is supposed to be scoped.